### PR TITLE
Add more vertical space between links

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -387,13 +387,14 @@ table th {
 
 .posts.flat .post h2 {
     font-size: 1.6rem;
+    margin-top: 0;
 }
 
 main article.single-link {
-    margin-bottom: 3rem;
+    margin-bottom: 5rem;
 }
 
-main article.single-link:last-child {
+main ul.posts li:last-child article.single-link {
     margin-bottom: unset;
 }
 


### PR DESCRIPTION
They say picture is worth 1000 words:

![afol-vertical-space](https://user-images.githubusercontent.com/12373754/89224403-b7b58400-d5d8-11ea-8b54-a6644be46a2e.png)

It's done by change in `main article.single-link`, remaining changes are to maintain similar distance on tag content list page (which can't be seen yet, as all tags contain only single link).